### PR TITLE
Add config options to agent helm chart

### DIFF
--- a/charts/monasca/Chart.yaml
+++ b/charts/monasca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Monasca running in Kubernetes
 name: monasca
-version: 0.1.6
+version: 0.1.7
 sources:
 - https://wiki.openstack.org/wiki/Monasca
 maintainers:

--- a/charts/monasca/templates/agent-daemonset.yaml
+++ b/charts/monasca/templates/agent-daemonset.yaml
@@ -64,3 +64,13 @@ spec:
               value: {{ .Values.agent.log_level | quote }}
             - name: HOSTNAME_FROM_KUBERNETES
               value: "true"
+            {{- if .Values.agent.namespace_annotations }}
+            - name: KUBERNETES_NAMESPACE_ANNOTATIONS
+              value: {{ .Values.agent.namespace_annotations | quote}}
+            {{- end}}
+            {{- if .Values.agent.kubernetes_api.storage.parameter_dimensions }}
+            - name: STORAGE_PARAMETERS_DIMENSIONS
+              value: {{ .Values.agent.kubernetes_api.storage.parameter_dimensions | quote}}
+            {{- end}}
+            - name: REPORT_PERSISTENT_STORAGE
+              value: {{ .Values.agent.kubernetes_api.storage.report | quote }}

--- a/charts/monasca/templates/agent-daemonset.yaml
+++ b/charts/monasca/templates/agent-daemonset.yaml
@@ -68,9 +68,3 @@ spec:
             - name: KUBERNETES_NAMESPACE_ANNOTATIONS
               value: {{ .Values.agent.namespace_annotations | quote}}
             {{- end}}
-            {{- if .Values.agent.kubernetes_api.storage.parameter_dimensions }}
-            - name: STORAGE_PARAMETERS_DIMENSIONS
-              value: {{ .Values.agent.kubernetes_api.storage.parameter_dimensions | quote}}
-            {{- end}}
-            - name: REPORT_PERSISTENT_STORAGE
-              value: {{ .Values.agent.kubernetes_api.storage.report | quote }}

--- a/charts/monasca/templates/agent-deployment.yaml
+++ b/charts/monasca/templates/agent-deployment.yaml
@@ -54,3 +54,9 @@ spec:
             - name: KUBERNETES_NAMESPACE_ANNOTATIONS
               value: {{ .Values.agent.namespace_annotations | quote}}
             {{- end}}
+            {{- if .Values.agent.kubernetes_api.storage.parameter_dimensions }}
+            - name: STORAGE_PARAMETERS_DIMENSIONS
+              value: {{ .Values.agent.kubernetes_api.storage.parameter_dimensions | quote}}
+            {{- end}}
+            - name: REPORT_PERSISTENT_STORAGE
+              value: {{ .Values.agent.kubernetes_api.storage.report | quote }}

--- a/charts/monasca/templates/agent-deployment.yaml
+++ b/charts/monasca/templates/agent-deployment.yaml
@@ -50,3 +50,7 @@ spec:
               value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
             - name: LOG_LEVEL
               value: {{ .Values.agent.log_level | quote }}
+            {{- if .Values.agent.namespace_annotations }}
+            - name: KUBERNETES_NAMESPACE_ANNOTATIONS
+              value: {{ .Values.agent.namespace_annotations | quote}}
+            {{- end}}

--- a/charts/monasca/templates/storm-nimbus-pvc.yaml
+++ b/charts/monasca/templates/storm-nimbus-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.thresh.storm_name }}"-nimbus
+    component: "{{ .Values.thresh.storm_name }}-nimbus"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/charts/monasca/values.yaml
+++ b/charts/monasca/values.yaml
@@ -83,6 +83,8 @@ agent:
   kubernetes_api:
     kubernetes_labels: 'app'
     timeout: 3
+    storage:
+      report: true
   kubernetes:
     kubernetes_labels: 'app'
     timeout: 3


### PR DESCRIPTION
Adds config option for collecting storage metrics and attaching
namespace annotations as dimensions