### PR TITLE
Add optional client deployment for testing

### DIFF
--- a/charts/monasca/templates/_helpers.tpl
+++ b/charts/monasca/templates/_helpers.tpl
@@ -103,3 +103,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "zookeeper.fullname" -}}
 {{- printf "%s-%s" .Release.Name "zookeeper" | trunc 63 -}}
 {{- end -}}
+
+{{/*
+Create a fully qualified client name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "client.fullname" -}}
+{{- printf "%s-%s" .Release.Name "client" | trunc 63 -}}
+{{- end -}}

--- a/charts/monasca/templates/client-deployment.yaml
+++ b/charts/monasca/templates/client-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: "{{ .Values.client.name }}-deployment"
+    component: "{{ .Values.client.name }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/charts/monasca/templates/client-deployment.yaml
+++ b/charts/monasca/templates/client-deployment.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.client.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "client.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.client.name }}-deployment"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  template:
+    metadata:
+      labels:
+        component: "{{ .Values.client.name }}-deployment"
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.client.name }}-deployment
+          image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag }}"
+          imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+          command: ["sleep", "infinity"]
+          env:
+            - name: OS_AUTH_URL
+              value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}/v3"
+            - name: OS_USERNAME
+              value: {{ .Values.client.keystone.os_username | quote }}
+            - name: OS_USER_DOMAIN_NAME
+              value: {{ .Values.client.keystone.os_user_domain_name | quote }}
+            - name: OS_PASSWORD
+              value: {{ .Values.client.keystone.os_password | quote }}
+            - name: OS_PROJECT_NAME
+              value: {{ .Values.client.keystone.os_project_name | quote }}
+            - name: OS_PROJECT_DOMAIN_NAME
+              value: {{ .Values.client.keystone.os_project_domain_name | quote }}
+            - name: MONASCA_URL
+              value: "http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0"
+{{- end }}

--- a/charts/monasca/values.yaml
+++ b/charts/monasca/values.yaml
@@ -279,4 +279,16 @@ zookeeper:
     accessMode: ReadWriteOnce
     size: 10Gi
 
-
+client:
+  name: client
+  enabled: false
+  image:
+    repository: rbrndt/python-monascaclient
+    tag: latest
+    pullPolicy: Always
+  keystone:
+    os_username: mini-mon
+    os_user_domain_name: Default
+    os_password: password
+    os_project_name: mini-mon
+    os_project_domain_name: Default


### PR DESCRIPTION
This adds an optional (disabled by default) deployment with a pre-configured python-monascaclient. The container will run continuously allowing it to be exec'd into, and has the `monasca` CLI installed and ready to use.