### PR TITLE
Add optional RBAC roles for agent

### DIFF
--- a/charts/monasca/templates/role-binding.yaml
+++ b/charts/monasca/templates/role-binding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  name: "monasca-role-binding"
+  name: "{{ .Release.Name }}-role-binding"
 subjects:
   - kind: ServiceAccount
     name: default

--- a/charts/monasca/templates/role-binding.yaml
+++ b/charts/monasca/templates/role-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.enabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: "monasca-role-binding"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "monitoring"
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-role"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/monasca/templates/role-binding.yaml
+++ b/charts/monasca/templates/role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: "monitoring"
+    namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole
   name: "{{ .Release.Name }}-role"

--- a/charts/monasca/templates/role.yaml
+++ b/charts/monasca/templates/role.yaml
@@ -2,8 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  #name: "{{ .Release.Name }}-role"
-  name: "monasca-role"
+  name: "{{ .Release.Name }}-role"
 rules:
   - apiGroups: ["", "extensions", "storage.k8s.io"]
     verbs: ["get", "list"]

--- a/charts/monasca/templates/role.yaml
+++ b/charts/monasca/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  #name: "{{ .Release.Name }}-role"
+  name: "monasca-role"
+rules:
+  - apiGroups: ["", "extensions", "storage.k8s.io"]
+    verbs: ["get", "list"]
+    resources:
+      - namespaces
+      - pods
+      - replicasets
+      - deployments
+      - replicationcontrollers
+      - nodes
+      - services
+      - componentstatuses
+      - storageclasses
+{{- end }}

--- a/charts/monasca/values.yaml
+++ b/charts/monasca/values.yaml
@@ -382,3 +382,6 @@ client:
     os_password: password
     os_project_name: mini-mon
     os_project_domain_name: Default
+
+rbac:
+  enabled: false


### PR DESCRIPTION
This adds default RBAC for all the resources used by the agent's k8s-aware plugins. It attaches the permissions to the default ServiceAccount for the namespace when `rbac.enabled = true` in `values.yaml`