### PR TITLE
Add seperate monasca-agent chart

### DIFF
--- a/monasca-agent/.helmignore
+++ b/monasca-agent/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/monasca-agent/Chart.yaml
+++ b/monasca-agent/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+description: A Helm chart for Monasca-agent
+name: monasca-agent
+version: 0.1.0
+sources:
+- https://github.com/openstack/monasca-agent
+maintainers:
+- name: Michael Hoppal
+  email: michael.jam.hoppal@hpe.com

--- a/monasca-agent/templates/_helpers.tpl
+++ b/monasca-agent/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/monasca-agent/templates/daemonset.yaml
+++ b/monasca-agent/templates/daemonset.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: "{{ template "fullname" . }}-daemonset"
+spec:
+  template:
+    metadata:
+      labels:
+        component: "{{ template "fullname" . }}-daemonset"
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}--daemonset
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          env:
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: AGENT_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES
+              value: "true"
+            - name: KUBERNETES_TIMEOUT
+              value: {{ .Values.kubernetes.timeout | quote }}
+            - name: KUBERNETES_LABELS
+              value: {{ .Values.kubernetes.kubernetes_labels | quote }}
+            - name: PROMETHEUS
+              value: {{ .Values.prometheus.auto_detect_pod_endpoints | quote }}
+            - name: PROMETHEUS_TIMEOUT
+              value: {{ .Values.prometheus.timeout | quote }}
+            - name: PROMETHEUS_DETECT_METHOD
+              value: pod
+            - name: PROMETHEUS_KUBERNETES_LABELS
+              value: {{ .Values.prometheus.kubernetes_labels | quote }}
+            - name: CADVISOR
+              value: {{ .Values.cadvisor.enabled | quote }}
+            - name: CADVISOR_TIMEOUT
+              value: {{ .Values.cadvisor.timeout | quote }}
+            - name: OS_AUTH_URL
+              value: {{ .Values.keystone.url | quote }}
+            - name: OS_USERNAME
+              value: {{ .Values.keystone.os_username | quote }}
+            - name: OS_USER_DOMAIN_NAME
+              value: {{ .Values.keystone.os_user_domain_name | quote }}
+            - name: OS_PASSWORD
+              value: {{ .Values.keystone.os_password | quote }}
+            - name: OS_PROJECT_NAME
+              value: {{ .Values.keystone.os_project_name | quote }}
+            - name: OS_PROJECT_DOMAIN_NAME
+              value: {{ .Values.keystone.os_project_domain_name | quote }}
+            - name: MONASCA_URL
+              value: {{ .Values.monasca_url | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.log_level | quote }}
+            - name: HOSTNAME_FROM_KUBERNETES
+              value: "true"
+            {{- if .Values.namespace_annotations }}
+            - name: KUBERNETES_NAMESPACE_ANNOTATIONS
+              value: {{ .Values.namespace_annotations | quote}}
+            {{- end}}

--- a/monasca-agent/templates/deployment.yaml
+++ b/monasca-agent/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: "{{ template "fullname" . }}-deployment"
+spec:
+  template:
+    metadata:
+      labels:
+        component: "{{ template "fullname" . }}-deployment"
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}--deployment
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          env:
+            - name: KUBERNETES_API
+              value: "true"
+            - name: KUBERNETES_API_TIMEOUT
+              value: {{ .Values.kubernetes_api.timeout | quote }}
+            - name: KUBERNETES_API_LABELS
+              value: {{ .Values.kubernetes_api.kubernetes_labels | quote }}
+            - name: PROMETHEUS
+              value: {{ .Values.prometheus.auto_detect_service_endpoints | quote }}
+            - name: PROMETHEUS_TIMEOUT
+              value: {{ .Values.prometheus.timeout | quote }}
+            - name: PROMETHEUS_DETECT_METHOD
+              value: service
+            - name: PROMETHEUS_KUBERNETES_LABELS
+              value: {{ .Values.prometheus.kubernetes_labels | quote }}
+            - name: OS_AUTH_URL
+              value: {{ .Values.keystone.url | quote }}
+            - name: OS_USERNAME
+              value: {{ .Values.keystone.os_username | quote }}
+            - name: OS_USER_DOMAIN_NAME
+              value: {{ .Values.keystone.os_user_domain_name | quote }}
+            - name: OS_PASSWORD
+              value: {{ .Values.keystone.os_password | quote }}
+            - name: OS_PROJECT_NAME
+              value: {{ .Values.keystone.os_project_name | quote }}
+            - name: OS_PROJECT_DOMAIN_NAME
+              value: {{ .Values.keystone.os_project_domain_name | quote }}
+            - name: MONASCA_URL
+              value: {{ .Values.monasca_url | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.log_level | quote }}
+            {{- if .Values.namespace_annotations }}
+            - name: KUBERNETES_NAMESPACE_ANNOTATIONS
+              value: {{ .Values.namespace_annotations | quote}}
+            {{- end}}
+            {{- if .Values.kubernetes_api.storage.parameter_dimensions }}
+            - name: STORAGE_PARAMETERS_DIMENSIONS
+              value: {{ .Values.kubernetes_api.storage.parameter_dimensions | quote}}
+            {{- end}}
+            - name: REPORT_PERSISTENT_STORAGE
+              value: {{ .Values.kubernetes_api.storage.report | quote }}

--- a/monasca-agent/values.yaml
+++ b/monasca-agent/values.yaml
@@ -1,0 +1,38 @@
+
+name: agent
+image:
+  repository: monasca/agent
+  tag: latest
+  pullPolicy: Always
+log_level: WARN
+keystone:
+  os_username: mini-mon
+  os_user_domain_name: Default
+  os_password: password
+  os_project_name: mini-mon
+  os_project_domain_name: Default
+  url: http://keystone:35357/v3
+monasca_url: http://monasca-api:8070/v2.0
+prometheus:
+  auto_detect_pod_endpoints: true
+  auto_detect_service_endpoints: true
+  kubernetes_labels: 'app'
+  timeout: 3
+kubernetes_api:
+  kubernetes_labels: 'app'
+  timeout: 3
+  storage:
+    report: true
+kubernetes:
+  kubernetes_labels: 'app'
+  timeout: 3
+cadvisor:
+  enabled: true
+  timeout: 3
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+  limits:
+    memory: 512Mi
+    cpu: 500m

--- a/monasca/templates/_helpers.tpl
+++ b/monasca/templates/_helpers.tpl
@@ -14,7 +14,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{/*
 
 {{/*
 Create a fully qualified agent name.


### PR DESCRIPTION
Will make it possible to install on seperate kubernetes clusters
and report back to one instance of monasca