### PR TITLE
Adjust resource requests and limits

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -143,7 +143,7 @@ api:
   resources:
     requests:
       memory: 256Mi
-      cpu: 250m
+      cpu: 100m
     limits:
       memory: 1Gi
       cpu: 2000m
@@ -285,7 +285,7 @@ notification:
       cpu: 50m
     limits:
       memory: 256Mi
-      cpu: 100m
+      cpu: 500m
 
 persister:
   name: persister
@@ -346,7 +346,7 @@ thresh:
   supervisor_resources:
     requests:
       memory: 2Gi
-      cpu: 500m
+      cpu: 250m
     limits:
       memory: 4Gi
       cpu: 2000m


### PR DESCRIPTION
This lowers several resource requests so Monasca can fit into the
default minikube environment (max 2 cores total), and raises the
limit for the persister so it can cope with metric load from larger
environments.