### PR TITLE
Move all MySQL credentials to a single location in values.yaml

### DIFF
--- a/monasca/README.md
+++ b/monasca/README.md
@@ -2,7 +2,7 @@
 
 ##  An Open-Source Monitoring as a Service at Scale solution
 
-[Monasca](https://wiki.openstack.org/wiki/Monasca), an [Openstack](https://www.openstack.org/) official project, is a 
+[Monasca](https://wiki.openstack.org/wiki/Monasca), an [Openstack](https://www.openstack.org/) official project, is a
 scalable monitoring as a service solution. It monitors services and systems by a push model. The Monasca Agent will
 collect metrics from each node and push them to the Monasca API. It will then be processed by separate microservices for
 storing, alarming and notifications. The architecture can be viewed [here](https://wiki.openstack.org/wiki/File:Monasca-arch-component-diagram.png)
@@ -97,8 +97,6 @@ Parameter | Description | Default
 `api.keystone.admin_password` | Keystone admin account password | `secretadmin`
 `api.keystone.admin_user` | Keystone admin account user | `admin`
 `api.keystone.admin_tenant` | Keystone admin account tenant | `admin`
-`api.mysql.user` | MySQL DB username | `monapi`
-`api.mysql.password` | MySQL DB password | `password`
 `api.influxdb.user` | The influx username | `mon_api`
 `api.influxdb.password` | The influx password | `password`
 `api.influxdb.database` | The influx database | `mon`
@@ -211,8 +209,6 @@ Parameter | Description | Default
 `keystone.bootstrap.service` | Keystone bootstrap service | `keystone`
 `keystone.bootstrap.region` | Keystone bootstrap region | `RegionOne`
 `keystone.database_backend` | Keystone backend database | `mysql`
-`keystone.mysql.user` | Keystone mysql user | `keystone`
-`keystone.mysql.password` | Keystone mysql password | `keystone`
 `keystone.mysql.database` | Keystone mysql database | `keystone`
 `keystone.replicaCount` | Keystone pod replicas | `1`
 `keystone.service.type` | Keystone service type | `ClusterIP`
@@ -228,6 +224,41 @@ Parameter | Description | Default
 `keystone.resources.limits.memory` | Memory limit per keystone pod | `1Gi`
 `keystone.resources.limits.cpu` | Memory limit per keystone pod | `500m`
 
+
+### MySQL
+
+Parameter | Description | Default
+----------|-------------|--------
+`mysql.imageTag` | Tag to use from `library/mysql` | `5.6`
+`mysql.imagePullPolicy` | K8s pull policy for mysql image | `IfNotPresent`
+`mysql.persistence.enabled` | If `true`, enable persistent storage | `false`
+`mysql.persistence.storageClass` | K8s storage class to use for persistence | `default`
+`mysql.persistence.accessMode` | PVC access mode | `ReadWriteOnce`
+`mysql.persistence.size` | PVC request size | `10Gi`
+`mysql.resources.requests.memory` | Memory request | `256Mi`
+`mysql.resources.requests.cpu` | CPU request | `100m`
+`mysql.resources.limits.memory` | Memory limit | `1Gi`
+`mysql.resources.limits.cpu` | CPU limit | `500m`
+`mysql.users.keystone.username` | Keystone MySQL username | `keystone`
+`mysql.users.keystone.password` | Keystone MySQL password | `keystone`
+`mysql.users.api.username` | API MySQL username | `monapi`
+`mysql.users.api.password` | API MySQL password | `password`
+`mysql.users.notification.username` | Notification MySQL username | `notification`
+`mysql.users.notification.password` | Notification MySQL password | `password`
+`mysql.users.thresh.username` | Thresh MySQL username | `thresh`
+`mysql.users.thresh.password` | Thresh MySQL password | `password`
+
+
+### MySQL Init
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`mysql_init.image.repository` | docker repository for mysql-init | `monasca/mysql-init`
+`mysql_init.image.tag` | Docker image tag | `1.2.0`
+`mysql_init.image.pullPolicy` | Kubernetes pull polify for image | `IfNotPresent`
+`mysql_init.disable_remote_root` | If `true`, disable root account after init finishes successfully | `true`
+
+
 ### Notification
 
 Parameter | Description | Default
@@ -237,8 +268,6 @@ Parameter | Description | Default
 `notification.image.tag` | Notification container image tag | `master`
 `notification.image.pullPolicy` | Notification container image pull policy | `Always`
 `notification.replicaCount` | Notification pod replica count | `1`
-`notification.mysql.user` | Notification mysql user | `notification`
-`notification.mysql.password` | Notification mysql user password | `password`
 `notification.log_level` | Notification log level | `WARN`
 `notification.plugins` | Notification plugins enabled | `pagerduty,webhook`
 `notification.resources.requests.memory` | Memory request per notification pod | `128Mi`
@@ -281,8 +310,6 @@ Parameter | Description | Default
 `thresh.persistence.enabled` | Zookeeper persistent storage enabled flag | `false`
 `thresh.persistence.accessMode` | Zookeeper persistent storage accessMode | `ReadWriteOnce`
 `thresh.persistence.size` | Zookeeper persistent storage size | `10Gi`
-`thresh.mysql.user` | Thresh mysql user | `thresh`
-`thresh.mysql.password` | Thresh mysql password | `password`
 `thresh.service.nimbus.port` | Storm nimbus service port | `6627`
 `thresh.service.nimbus.type` | Storm nimbus service type | `ClusterIP`
 `thresh.spout.metricSpoutThreads` | Amount of metric spout threads | `2`
@@ -329,4 +356,3 @@ $ helm install monasca --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-

--- a/monasca/templates/api-deployment.yaml
+++ b/monasca/templates/api-deployment.yaml
@@ -51,11 +51,17 @@ spec:
             - name: MYSQL_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: MYSQL_USER
-              value: {{ .Values.api.mysql.user | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-api-secret"
+                  key: username
             - name: MYSQL_PASSWORD
-              value: {{ .Values.api.mysql.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-api-secret"
+                  key: password
             - name: MYSQL_DB
-              value: {{ .Values.mysql.mysqlDatabase | quote }}
+              value: "mon"
             - name: KEYSTONE_IDENTITY_URI
               value: "http://{{ template "keystone.fullname" . }}:{{ .Values.keystone.service.port }}"
             - name: KEYSTONE_AUTH_URI

--- a/monasca/templates/keystone-deployment.yaml
+++ b/monasca/templates/keystone-deployment.yaml
@@ -51,9 +51,15 @@ spec:
             - name: KEYSTONE_MYSQL_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: KEYSTONE_MYSQL_USER
-              value: {{ .Values.keystone.mysql.user | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-keystone-secret"
+                  key: username
             - name: KEYSTONE_MYSQL_PASSWORD
-              value: {{ .Values.keystone.mysql.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-keystone-secret"
+                  key: password
             - name: KEYSTONE_MYSQL_DATABASE
               value: {{ .Values.keystone.mysql.database | quote }}
             - name: KEYSTONE_MYSQL_TCP_PORT

--- a/monasca/templates/mysql-api-secret.yaml
+++ b/monasca/templates/mysql-api-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-mysql-api-secret"
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  username: {{ b64enc .Values.mysql.users.api.username | quote }}
+  password: {{ b64enc .Values.mysql.users.api.password | quote }}

--- a/monasca/templates/mysql-init-job.yaml
+++ b/monasca/templates/mysql-init-job.yaml
@@ -22,12 +22,55 @@ spec:
             - name: MYSQL_INIT_DISABLE_REMOTE_ROOT
               value: {{ .Values.mysql_init.disable_remote_root | quote }}
             - name: MYSQL_INIT_RANDOM_PASSWORD
-              value: {{ .Values.mysql_init.randon_password | quote }}
+              value: "false"
             - name: MYSQL_INIT_HOST
               value: "{{ .Release.Name }}-mysql"
             - name: MYSQL_INIT_PORT
               value: {{ .Values.mysql_init.port | quote }}
             - name: MYSQL_INIT_USERNAME
-              value: {{ .Values.mysql_init.username }}
+              value: "root"
             - name: MYSQL_INIT_PASSWORD
-              value: {{ .Values.mysql_init.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql"
+                  key: "mysql-root-password"
+            - name: KEYSTONE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-keystone-secret"
+                  key: username
+            - name: KEYSTONE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-keystone-secret"
+                  key: password
+            - name: API_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-api-secret"
+                  key: username
+            - name: API_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-api-secret"
+                  key: password
+            - name: NOTIFICATION_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-notification-secret"
+                  key: username
+            - name: NOTIFICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-notification-secret"
+                  key: password
+            - name: THRESH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-thresh-secret"
+                  key: username
+            - name: THRESH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-thresh-secret"
+                  key: password

--- a/monasca/templates/mysql-keystone-secret.yaml
+++ b/monasca/templates/mysql-keystone-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-mysql-keystone-secret"
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  username: {{ b64enc .Values.mysql.users.keystone.username | quote }}
+  password: {{ b64enc .Values.mysql.users.keystone.password | quote }}

--- a/monasca/templates/mysql-notification-secret.yaml
+++ b/monasca/templates/mysql-notification-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-mysql-notification-secret"
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  username: {{ b64enc .Values.mysql.users.notification.username | quote }}
+  password: {{ b64enc .Values.mysql.users.notification.password | quote }}

--- a/monasca/templates/mysql-thresh-secret.yaml
+++ b/monasca/templates/mysql-thresh-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-mysql-thresh-secret"
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  username: {{ b64enc .Values.mysql.users.thresh.username | quote }}
+  password: {{ b64enc .Values.mysql.users.thresh.password | quote }}

--- a/monasca/templates/notification-deployment.yaml
+++ b/monasca/templates/notification-deployment.yaml
@@ -28,11 +28,17 @@ spec:
             - name: MYSQL_DB_PORT
               value: "3306"
             - name: MYSQL_DB_USERNAME
-              value: {{ .Values.notification.mysql.user | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-notification-secret"
+                  key: username
             - name: MYSQL_DB_PASSWORD
-              value: {{ .Values.notification.mysql.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mysql-notification-secret"
+                  key: password
             - name: MYSQL_DB_DATABASE
-              value: {{ .Values.mysql.mysqlDatabase | quote }}
+              value: "mon"
             - name: KAFKA_URI
               value: "{{ template "kafka.fullname" . }}:{{ .Values.kafka.service.port }}"
             - name: ZOOKEEPER_URL

--- a/monasca/templates/thresh-configmap.yaml
+++ b/monasca/templates/thresh-configmap.yaml
@@ -105,9 +105,9 @@ data:
 
     database:
       driverClass: com.mysql.jdbc.Driver
-      url: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.mysqlDatabase }}?useSSL=true"
-      user: {{ .Values.thresh.mysql.user | quote }}
-      password: {{ .Values.thresh.mysql.password | quote }}
+      url: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/mon?useSSL=true"
+      user: {{ .Values.mysql.users.thresh.username | quote }}
+      password: {{ .Values.mysql.users.thresh.password | quote }}
       properties:
           ssl: false
       # the maximum amount of time to wait on an empty pool before throwing an exception

--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -1,10 +1,9 @@
 mysql_init:
   image:
     repository: monasca/mysql-init
-    tag: 1.1.0
+    tag: 1.2.0
     pullPolicy: IfNotPresent
   disable_remote_root: true
-  randon_password: true
 
 influx_init:
   image:
@@ -49,8 +48,6 @@ influxdb:
 
 mysql:
   imageTag: "5.6"
-  mysqlRootPassword: "secretmysql"
-  mysqlDatabase: "mon"
   imagePullPolicy: IfNotPresent
   persistence:
     enabled: false
@@ -64,6 +61,19 @@ mysql:
     limits:
       memory: 1Gi
       cpu: 500m
+  users:
+    api:
+      username: monapi
+      password: password
+    notification:
+      username: notification
+      password: password
+    thresh:
+      username: thresh
+      password: password
+    keystone:
+      username: keystone
+      password: keystone
 
 agent:
   name: agent
@@ -113,9 +123,6 @@ api:
     admin_password: secretadmin
     admin_user: admin
     admin_tenant: admin
-  mysql:
-    user: monapi
-    password: password
   influxdb:
     user: mon_api
     password: password
@@ -239,8 +246,6 @@ keystone:
     tag: 1.0.7
     repository: monasca/keystone
   mysql:
-    user: keystone
-    password: keystone
     database: keystone
   replicaCount: 1
   service:
@@ -273,9 +278,6 @@ notification:
     tag: master
     pullPolicy: Always
   replicaCount: 1
-  mysql:
-    user: notification
-    password: password
   log_level: WARN
   plugins: pagerduty,webhook
   resources:
@@ -327,9 +329,6 @@ thresh:
       repository: rbrndt/monasca-thresh
       tag: latest
       pullPolicy: Always
-  mysql:
-    user: thresh
-    password: password
   persistence:
     storageClass: default
     enabled: false


### PR DESCRIPTION
This moves all mysql credentials to `mysql.users.*` and allows accounts
to be changed in a single location. Additionally, credentials for each
service (API, notification engine, thresh, keystone) are now stored in
secrets.

Note that thresh does not yet yet make use of its secret as the
credentials currently must be kept in a ConfigMap. This will be
resolved once the storm/thresh charts are updated to use the
refactored images.

Additionally, this removes the configurable `mysqlDatabase` parameter
as it wasn't truly configurable. Changing it from the default would
break deployment in (almost) all cases as mysql-init doesn't honor the
parameter, and more generally it isn't something that needs to be
user-configurable.