### PR TITLE
Resolve public keystone endpoints when NodePorts are enabled

### DIFF
--- a/monasca/templates/keystone-configmap.yaml
+++ b/monasca/templates/keystone-configmap.yaml
@@ -46,5 +46,16 @@ data:
         description: Monasca monitoring service
         type: monitoring
         region: RegionOne
-        url: http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0
-        interfaces: ['public', 'internal', 'admin']
+        interfaces:
+          - name: internal
+            url: http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0
+          - name: public
+            url: http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0
+            {{- if .Values.api.service.node_port }}
+            resolve: true
+            {{- end }}
+          - name: admin
+            url: http://{{ template "api.fullname" . }}:{{ .Values.api.service.port }}/v2.0
+            {{- if .Values.api.service.node_port }}
+            resolve: true
+            {{- end }}

--- a/monasca/templates/keystone-deployment.yaml
+++ b/monasca/templates/keystone-deployment.yaml
@@ -64,6 +64,14 @@ spec:
               value: {{ .Values.keystone.mysql.database | quote }}
             - name: KEYSTONE_MYSQL_TCP_PORT
               value: "3306"
+            {{- if .Values.keystone.service.node_port }}
+            {{- if .Values.keystone.service.admin_node_port }}
+            - name: KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS
+              value: "true"
+            - name: KEYSTONE_SERVICE_NAME
+              value: "{{ template "keystone.fullname" . }}"
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 5000


### PR DESCRIPTION
This adds support for the keystone endpoint resolver added in hpcloud-mon/monasca-docker#26. It will automatically enable public endpoint resolution if NodePorts are enabled for one or both of Keystone itself or the Monasca API.