### PR TITLE
Update grafana container version

### DIFF
--- a/monasca/values.yaml
+++ b/monasca/values.yaml
@@ -188,7 +188,7 @@ grafana:
   name: grafana
   image:
     repository: monasca/grafana
-    tag: 4.1.0-pre1-1.0.0
+    tag: 4.0.0-1.1.0
     pullPolicy: Always
   service:
     type: NodePort


### PR DESCRIPTION
This updates values.yaml to use the latest version of monasca/grafana.
The container now includes the monasca-grafana-app and switches to the
latest sapcc/grafana revision of grafana with keystone patches
applied.